### PR TITLE
named functions more consistently

### DIFF
--- a/include/flight_planner.h
+++ b/include/flight_planner.h
@@ -89,10 +89,10 @@ class FlightPlannerBase : public GraphDirected<StateAircraft> {
   const auto& airports() const { return airports_; }
 
   /// Returns the number of airports
-  int numAirports() const { return airports().size(); }
+  int NumAirports() const { return airports().size(); }
 
   /// Returns the airport with the given IdCity
-  const row& getAirport(const IdCity id) const { return airports()[id.id()]; }
+  const row& GetAirport(const IdCity id) const { return airports()[id.id()]; }
 
  protected:
   /// Adds charging edges for each city in the graph
@@ -110,9 +110,9 @@ class FlightPlannerBase : public GraphDirected<StateAircraft> {
   void AddEdgesCharge(const IdCity id_city, const set<StateAircraft>& vertex_states);
 
   // Gets the IdCity from the name of the city
-  IdCity GetIdCityFromName(const string& name) const;
+  IdCity GetIdCity(const string& name) const;
 
-  void PrintCity(const IdCity& id_city) const { cout << getAirport(id_city).name; }
+  void PrintCity(const IdCity& id_city) const { cout << GetAirport(id_city).name; }
   void PrintCity(const StateAircraft& state) const { PrintCity(state.id_city()); }
 
   // Prints out the path
@@ -122,7 +122,7 @@ class FlightPlannerBase : public GraphDirected<StateAircraft> {
   void PrintChargingCitiesAndTimes(const vector<StateAircraft>& v_path, IdCity id_dst) const;
 
   // Returns the latitude and longitude of the city in radians
-  pair<double, double> getLatLonRadians(IdCity id_city) const;
+  pair<double, double> GetLatLonRadians(IdCity id_city) const;
 
   // Calculates the distance between two cities in km
   double CalcDistKm(IdCity src, IdCity dst) const;
@@ -131,7 +131,7 @@ class FlightPlannerBase : public GraphDirected<StateAircraft> {
   double CalcChargeTime(const StateAircraft& state_lo, const StateAircraft& state_hi) const;
 
   // Calculates the charge rate at a city in km/hr
-  double CalcChargeRateKmPerHr(const IdCity& id_city) const { return getAirport(id_city).rate; }
+  double CalcChargeRateKmPerHr(const IdCity& id_city) const { return GetAirport(id_city).rate; }
 
   static constexpr double RadEarth() { return 6356.752; }  // Radius of Earth in km
   static constexpr double SpeedKmPerHr() { return 105.0; }  // Speed of aircraft in km/hr
@@ -185,7 +185,7 @@ class FlightPlannerGrid : public FlightPlannerBase {
 
   void AddVerticesGrid();
 
-  int findBatteryLevel(const double battery_level) const;
+  int FindBatteryLevel(const double battery_level) const;
 
   void AddEdgesDrivingGrid();
 

--- a/include/graph_directed.h
+++ b/include/graph_directed.h
@@ -23,30 +23,30 @@ class GraphDirected {
   ~GraphDirected() = default;                                // Destructor
 
   /// Adds a vertex to the graph if it doesn't already exist, otherwise has no effect
-  void addVertex(const VertexType& v) { vertices_.insert(v); }
+  void AddVertex(const VertexType& v) { vertices_.insert(v); }
 
   /// Add a directed edge to the graph from vertex src to vertex dst with weight w
-  void addDirectedEdge(const VertexType& src, const VertexType& dst, double w) {
-    addVertex(src);
-    addVertex(dst);
+  void AddDirectedEdge(const VertexType& src, const VertexType& dst, double w) {
+    AddVertex(src);
+    AddVertex(dst);
     assert(0.0 <= w);             // Assert edge cost is non-negative
-    adjacencyList[src][dst] = w;  // Add edge to the adjacency list
+    adjacency_list_[src][dst] = w;  // Add edge to the adjacency list
   }
 
   /// Returns the number of vertices in the graph
-  int getNumVertices() const { return vertices().size(); }
+  int NumVertices() const { return vertices().size(); }
 
   /// Returns the number of edges in the graph
-  int getNumEdges() const {
+  int NumEdges() const {
     int numEdges = 0;
-    for (const auto &v_it : adjacencyList) {
+    for (const auto &v_it : adjacency_list()) {
       numEdges += v_it.second.size();
     }
     return numEdges;
   }
 
   /// Perform Dijkstra's algorithm to find the shortest path between vertices src and dst
-  pair<vector<VertexType>, double> calcMinCostPathDijkstra(const VertexType& src, const VertexType& dst) const {
+  pair<vector<VertexType>, double> CalcMinCostPathDijkstra(const VertexType& src, const VertexType& dst) const {
     // Initialize distances, visited array, and parent map
     map<VertexType, double> dist;
     map<VertexType, bool> visited;
@@ -74,7 +74,7 @@ class GraphDirected {
       if (visited[u]) { continue; }
       visited[u] = true;
 
-      for (const auto &vertex_and_edge_cost : adjacencyList.at(u)) {
+      for (const auto &vertex_and_edge_cost : adjacency_list().at(u)) {
         const auto& [v, cost_uv] = vertex_and_edge_cost;
         double dist_alt = dist[u] + cost_uv;
         if (!visited[v] && dist_alt < dist[v]) {
@@ -104,11 +104,11 @@ class GraphDirected {
   }
 
   const set<VertexType>& vertices() const { return vertices_; }
-  const map<VertexType, map<VertexType, double>>& getAdjacencyList() const { return adjacencyList; }
+  const map<VertexType, map<VertexType, double>>& adjacency_list() const { return adjacency_list_; }
 
  private:
   set<VertexType> vertices_;  // List of vertices in the graph
-  map<VertexType, map<VertexType, double>> adjacencyList;  // Adjacency list of the graph
+  map<VertexType, map<VertexType, double>> adjacency_list_;  // Adjacency list of the graph
 };
 
 };  // namespace std

--- a/readme.md
+++ b/readme.md
@@ -203,10 +203,10 @@ Finding the discrete battery level closest to the true battery level without goi
 ## Graph size + solution quality
 
 The exact graph size is fixed, and is comparable to an approximate graph when $8 ≤ n ≤ 32$ as shown in the table below.
-For the graph that uses a approximate of $n$ battery levels, the flight time decreases as $n$ increases.
-The decreasing flying times approach the flying time of the exact solution.
+For the graph that uses a approximate of $n$ battery levels, the total time decreases as $n$ increases.
+The decreasing total times approach the total time of the exact solution.
 
-| Battery Levels | Vertex # | Edge #    | Drive Time*|
+| Battery Levels | Vertex # | Edge #    | Total Time*|
 |----------------|----------|-----------|------------|
 | n = 8          |  2,424   | 19,328    | 68.8800    |
 | n = 32         |  9,696   | 77,212    | 67.1495    |

--- a/test/flight_planner_test.cpp
+++ b/test/flight_planner_test.cpp
@@ -13,37 +13,37 @@ namespace std {
 
 TEST(GraphCheck, RegressionTestExact) {
   const auto airport_graph = FlightPlannerExact(airports);
-  ASSERT_EQ(airport_graph.numAirports(), 303);
-  ASSERT_EQ(airport_graph.getNumVertices(), 9918);
-  ASSERT_EQ(airport_graph.getNumEdges(), 28542);
+  ASSERT_EQ(airport_graph.NumAirports(), 303);
+  ASSERT_EQ(airport_graph.NumVertices(), 9918);
+  ASSERT_EQ(airport_graph.NumEdges(), 28542);
 }
 
 TEST(GraphCheck, RegressionTestGrid_8) {
   const auto airport_graph = FlightPlannerGrid(airports, 8);
-  ASSERT_EQ(airport_graph.numAirports(), 303);
-  ASSERT_EQ(airport_graph.getNumVertices(), 2424);
-  ASSERT_EQ(airport_graph.getNumEdges(), 19328);
+  ASSERT_EQ(airport_graph.NumAirports(), 303);
+  ASSERT_EQ(airport_graph.NumVertices(), 2424);
+  ASSERT_EQ(airport_graph.NumEdges(), 19328);
 }
 
 TEST(GraphCheck, RegressionTestGrid_32) {
   const auto airport_graph = FlightPlannerGrid(airports, 32);
-  ASSERT_EQ(airport_graph.numAirports(), 303);
-  ASSERT_EQ(airport_graph.getNumVertices(), 9696);
-  ASSERT_EQ(airport_graph.getNumEdges(), 77212);
+  ASSERT_EQ(airport_graph.NumAirports(), 303);
+  ASSERT_EQ(airport_graph.NumVertices(), 9696);
+  ASSERT_EQ(airport_graph.NumEdges(), 77212);
 }
 
 TEST(GraphCheck, RegressionTestGrid_128) {
   const auto airport_graph = FlightPlannerGrid(airports, 128);
-  ASSERT_EQ(airport_graph.numAirports(), 303);
-  ASSERT_EQ(airport_graph.getNumVertices(), 38784);
-  ASSERT_EQ(airport_graph.getNumEdges(), 309080);
+  ASSERT_EQ(airport_graph.NumAirports(), 303);
+  ASSERT_EQ(airport_graph.NumVertices(), 38784);
+  ASSERT_EQ(airport_graph.NumEdges(), 309080);
 }
 
 TEST(GraphCheck, RegressionTestGrid_512) {
   const auto airport_graph = FlightPlannerGrid(airports, 512);
-  ASSERT_EQ(airport_graph.numAirports(), 303);
-  ASSERT_EQ(airport_graph.getNumVertices(), 155136);
-  ASSERT_EQ(airport_graph.getNumEdges(), 1236666);
+  ASSERT_EQ(airport_graph.NumAirports(), 303);
+  ASSERT_EQ(airport_graph.NumVertices(), 155136);
+  ASSERT_EQ(airport_graph.NumEdges(), 1236666);
 }
 
 


### PR DESCRIPTION
Use lower case for getters, and upper case for calculated member functions.