### PR TITLE
removed `namespace std`

### DIFF
--- a/include/flight_planner.h
+++ b/include/flight_planner.h
@@ -18,8 +18,6 @@
 #include "./airports.h"
 #include "./graph_directed.h"
 
-namespace std {
-
 
 /// Represents the ID of a city in the airport list
 class IdCity {
@@ -84,7 +82,7 @@ class FlightPlannerBase : public GraphDirected<StateAircraft> {
   explicit FlightPlannerBase(const std::array<row, 303>& airports) : airports_(airports) {}
 
   /// Solves for the minimum time path
-  pair<vector<StateAircraft>, double> SolvePath(const char* char_src, const char* char_dst) const;
+  std::pair<std::vector<StateAircraft>, double> SolvePath(const char* char_src, const char* char_dst) const;
 
   /// Solves for the minimum time path and prints it out
   void SolvePathAndPrint(const char* char_src, const char* char_dst) const {
@@ -119,22 +117,22 @@ class FlightPlannerBase : public GraphDirected<StateAircraft> {
 
  private:
   // Adds charging edges for a given city
-  void AddEdgesCharge(const IdCity& id_city, const set<StateAircraft>& vertex_states);
+  void AddEdgesCharge(const IdCity& id_city, const std::set<StateAircraft>& vertex_states);
 
   // Gets the IdCity from the name of the city
-  IdCity GetIdCity(const string& name) const;
+  IdCity GetIdCity(const std::string& name) const;
 
-  void PrintCity(const IdCity& id_city) const { cout << GetAirport(id_city).name; }
+  void PrintCity(const IdCity& id_city) const { std::cout << GetAirport(id_city).name; }
   void PrintCity(const StateAircraft& state) const { PrintCity(state.id_city()); }
 
   // Prints out the path
-  void PrintPath(const vector<StateAircraft>& v_path) const;
+  void PrintPath(const std::vector<StateAircraft>& v_path) const;
 
   // Prints out the cities the plane charges at and the time it charges at each city
-  void PrintChargingCitiesAndTimes(const vector<StateAircraft>& v_path, const IdCity& id_dst) const;
+  void PrintChargingCitiesAndTimes(const std::vector<StateAircraft>& v_path) const;
 
   // Returns the latitude and longitude of the city in radians
-  pair<double, double> GetLatLonRadians(const IdCity& id_city) const;
+  std::pair<double, double> GetLatLonRadians(const IdCity& id_city) const;
 
   // Calculates the distance between two cities in km
   double CalcDistKm(const IdCity& src, const IdCity& dst) const;
@@ -184,14 +182,14 @@ class FlightPlannerGrid : public FlightPlannerBase {
   int n_levels() const { return n_levels_; }
 
   /// Returns the vector of evenly spaced battery levels
-  const vector<double>& v_battery_levels() const { return v_battery_levels_; }
+  const std::vector<double>& v_battery_levels() const { return v_battery_levels_; }
 
  private:
   // Creates a vector of evenly spaced battery levels between the minimum and maximum battery levels
-  static vector<double> CreateGridBatteryLevels(int n_levels) {
+  static std::vector<double> CreateGridBatteryLevels(int n_levels) {
     const double delta_battery = (MaxBatteryHours() - MinBatteryHours()) / (n_levels - 1);
 
-    vector<double> v_battery_levels;
+    std::vector<double> v_battery_levels;
     for (int i = 0; i < n_levels; i++) {
       double battery_level = MinBatteryHours() + delta_battery * i;
       v_battery_levels.push_back(battery_level);
@@ -210,7 +208,5 @@ class FlightPlannerGrid : public FlightPlannerBase {
   void AddEdgesDrivingGrid();
 
   const int n_levels_;  // Number of evenly spaced battery levels in the grid
-  const vector<double> v_battery_levels_;  // Vector of evenly spaced battery levels
+  const std::vector<double> v_battery_levels_;  // Vector of evenly spaced battery levels
 };
-
-};  // namespace std

--- a/include/graph_directed.h
+++ b/include/graph_directed.h
@@ -9,7 +9,6 @@
 #include <limits>
 #include <cassert>
 
-namespace std {
 
 /// Graph class for a directed graph with vertices of type VertexType
 template <typename VertexType>
@@ -46,14 +45,15 @@ class GraphDirected {
   }
 
   /// Perform Dijkstra's algorithm to find the shortest path between vertices src and dst
-  pair<vector<VertexType>, double> CalcMinCostPathDijkstra(const VertexType& src, const VertexType& dst) const {
+  std::pair<std::vector<VertexType>, double> CalcMinCostPathDijkstra(const VertexType& src,
+                                                                     const VertexType& dst) const {
     // Initialize distances, visited array, and parent map
-    map<VertexType, double> dist;
-    map<VertexType, bool> visited;
-    map<VertexType, VertexType> parent;
+    std::map<VertexType, double> dist;
+    std::map<VertexType, bool> visited;
+    std::map<VertexType, VertexType> parent;
 
     for (const VertexType& v : vertices()) {
-      dist[v] = numeric_limits<double>::infinity();
+      dist[v] = std::numeric_limits<double>::infinity();
       visited[v] = false;
       parent[v] = VertexType();
     }
@@ -61,7 +61,9 @@ class GraphDirected {
     dist[src] = 0;
 
     // Priority queue to store vertices and their distances
-    priority_queue<pair<double, VertexType>, vector<pair<double, VertexType>>, greater<pair<double, VertexType>>> pq;
+    std::priority_queue<std::pair<double, VertexType>,
+                        std::vector<std::pair<double, VertexType>>,
+                        std::greater<std::pair<double, VertexType>>> pq;
 
     // Add the source vertex to the priority queue
     pq.emplace(dist[src], src);
@@ -90,7 +92,7 @@ class GraphDirected {
     }
 
     // Reconstruct the shortest path
-    vector<VertexType> path;
+    std::vector<VertexType> path;
     VertexType current = dst;
     while (current != src) {
       path.push_back(current);
@@ -98,7 +100,7 @@ class GraphDirected {
       if (current == VertexType()) {
         // The current vertex has no parent, which means that it is not
         // reachable from the source vertex, and hence there is no valid path
-        return make_pair(vector<VertexType>(), numeric_limits<double>::infinity());
+        return make_pair(std::vector<VertexType>(), std::numeric_limits<double>::infinity());
       }
     }
 
@@ -108,14 +110,12 @@ class GraphDirected {
   }
 
   /// Returns the set of vertices in the graph
-  const set<VertexType>& vertices() const { return vertices_; }
+  const std::set<VertexType>& vertices() const { return vertices_; }
 
   /// Returns the adjacency list of the graph
-  const map<VertexType, map<VertexType, double>>& adjacency_list() const { return adjacency_list_; }
+  const std::map<VertexType, std::map<VertexType, double>>& adjacency_list() const { return adjacency_list_; }
 
  private:
-  set<VertexType> vertices_;  // List of vertices in the graph
-  map<VertexType, map<VertexType, double>> adjacency_list_;  // Adjacency list of the graph
+  std::set<VertexType> vertices_;  // List of vertices in the graph
+  std::map<VertexType, std::map<VertexType, double>> adjacency_list_;  // Adjacency list of the graph
 };
-
-};  // namespace std

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,12 +2,9 @@
 #include "../include/flight_planner.h"
 
 
-using namespace std;
-
-
 int main(int argc, char** argv) {
   if (argc != 3) {
-    cout << "Invalid number of arguments" << endl;
+    std::cout << "Invalid number of arguments" << std::endl;
     return 1;
   }
 
@@ -15,4 +12,4 @@ int main(int argc, char** argv) {
   // FlightPlannerGrid(airports, 4).SolvePathAndPrint(argv[1], argv[2]);  // Run the grid planner
 
   return 0;
-};
+}

--- a/test/flight_planner_test.cpp
+++ b/test/flight_planner_test.cpp
@@ -2,14 +2,14 @@
 #include "../include/airports.h"
 
 #include <gtest/gtest.h>
-#include <filesystem>
+
+#include <string>
 #include <regex>
+#include <filesystem>
 
 
 static bool USE_FAST_TEST = true;
 
-
-namespace std {
 
 TEST(GraphCheck, RegressionTestExact) {
   const auto airport_graph = FlightPlannerExact(airports);
@@ -58,8 +58,8 @@ std::vector<std::pair<std::string, std::string>> generateCityPairs(const std::ar
     for (size_t i = 0; i < cities.size(); ++i) {
       for (size_t j = i + 1; j < cities.size(); ++j) {
         if (i == j) continue;  // Reference solution does not handle this case
-        const string& name_i = cities[i].name;
-        const string& name_j = cities[j].name;
+        const std::string& name_i = cities[i].name;
+        const std::string& name_j = cities[j].name;
         cityPairs.emplace_back(name_i, name_j);
       }
     }
@@ -81,9 +81,9 @@ std::vector<std::pair<std::string, std::string>> generateCityPairs(const std::ar
 class FlightPathTester : public ::testing::Test {
  protected:
   // Helper function to execute the checker and capture its output
-  std::string runTestCities(const pair<string, string>& cityPair) const {
-    const string escape_city_name_1 = escapeCityName(cityPair.first);
-    const string escape_city_name_2 = escapeCityName(cityPair.second);
+  std::string runTestCities(const std::pair<std::string, std::string>& cityPair) const {
+    const std::string escape_city_name_1 = escapeCityName(cityPair.first);
+    const std::string escape_city_name_2 = escapeCityName(cityPair.second);
 
     // TODO(ryanelandt): detect operating system and use the appropriate checker
     std::string command = "../checker_linux \"$(./flight_planner " +
@@ -151,19 +151,19 @@ class FlightPathTester : public ::testing::Test {
     return findNumberAfterString(output, candidate_success_string());
   }
 
-  const string& reference_success_string() const { return reference_success_string_; }
-  const string& candidate_success_string() const { return candidate_success_string_; }
+  const std::string& reference_success_string() const { return reference_success_string_; }
+  const std::string& candidate_success_string() const { return candidate_success_string_; }
 
  private:
-  const string reference_success_string_ = "Reference result: Success, cost was ";
-  const string candidate_success_string_ = "Candidate result: Success, cost was ";
+  const std::string reference_success_string_ = "Reference result: Success, cost was ";
+  const std::string candidate_success_string_ = "Candidate result: Success, cost was ";
 };
 
 
 
 // Test that the tester calculated travel times agree with the console output
 TEST_F(FlightPathTester, TestParseOutput) {
-  const string output = runTestCities({"Manteca_CA", "Fort_Myers_FL"});
+  const std::string output = runTestCities({"Manteca_CA", "Fort_Myers_FL"});
   ASSERT_EQ(getReferenceCost(output), 67.3259);
   ASSERT_EQ(getCandidateCost(output), 66.1095);
 }
@@ -240,5 +240,3 @@ TEST(Linspaced, Convergence) {
   EXPECT_LT(cost_128, cost_64);
   EXPECT_LT(cost_256, cost_128);
 }
-
-};  // namespace std

--- a/test/graph_directed_test.cpp
+++ b/test/graph_directed_test.cpp
@@ -6,8 +6,6 @@
 
 
 
-namespace std {
-
 //
 //            4       5                     //
 //      A----------►D----►E                 //
@@ -19,8 +17,8 @@ namespace std {
 //      B----------►C                       //
 //           2                              //
 //
-static GraphDirected<string> makeTestGraph() {
-  GraphDirected<string> graph;
+static GraphDirected<std::string> makeTestGraph() {
+  GraphDirected<std::string> graph;
   graph.AddDirectedEdge("A", "B", 1.0);
   graph.AddDirectedEdge("A", "D", 4.0);
   graph.AddDirectedEdge("B", "C", 2.0);
@@ -62,31 +60,31 @@ TEST(GraphTest, DijkstraA) {
     // "A" --> "A"
     const auto dj_AA = graph.CalcMinCostPathDijkstra("A", "A");
     EXPECT_EQ(dj_AA.second, 0.0);
-    EXPECT_EQ(dj_AA.first, vector<string>({"A"}));
+    EXPECT_EQ(dj_AA.first, std::vector<std::string>({"A"}));
   }
   {
     // "A" --> "B"
     const auto dj_AB = graph.CalcMinCostPathDijkstra("A", "B");
     EXPECT_EQ(dj_AB.second, 1.0);
-    EXPECT_EQ(dj_AB.first, vector<string>({"A", "B"}));
+    EXPECT_EQ(dj_AB.first, std::vector<std::string>({"A", "B"}));
   }
   {
     // "A" --> "C"
     const auto dj_AC = graph.CalcMinCostPathDijkstra("A", "C");
     EXPECT_EQ(dj_AC.second, 3.0);
-    EXPECT_EQ(dj_AC.first, vector<string>({"A", "B", "C"}));
+    EXPECT_EQ(dj_AC.first, std::vector<std::string>({"A", "B", "C"}));
   }
   {
     // "A" --> "D"
     const auto dj_AD = graph.CalcMinCostPathDijkstra("A", "D");
     EXPECT_EQ(dj_AD.second, 3.0);
-    EXPECT_EQ(dj_AD.first, vector<string>({"A", "B", "C", "D"}));
+    EXPECT_EQ(dj_AD.first, std::vector<std::string>({"A", "B", "C", "D"}));
   }
   {
     // "A" --> "E"
     const auto dj_AE = graph.CalcMinCostPathDijkstra("A", "E");
     EXPECT_EQ(dj_AE.second, 6.0);
-    EXPECT_EQ(dj_AE.first, vector<string>({"A", "B", "C", "E"}));
+    EXPECT_EQ(dj_AE.first, std::vector<std::string>({"A", "B", "C", "E"}));
   }
 }
 
@@ -95,32 +93,32 @@ TEST(GraphTest, DijkstraB) {
   {
     // "B" --> "A"
     const auto dj_BA = graph.CalcMinCostPathDijkstra("B", "A");
-    EXPECT_EQ(dj_BA.second, numeric_limits<double>::infinity());
-    EXPECT_EQ(dj_BA.first, vector<string>());
+    EXPECT_EQ(dj_BA.second, std::numeric_limits<double>::infinity());
+    EXPECT_EQ(dj_BA.first, std::vector<std::string>());
   }
   {
     // "B" --> "B"
     const auto dj_BB = graph.CalcMinCostPathDijkstra("B", "B");
     EXPECT_EQ(dj_BB.second, 0.0);
-    EXPECT_EQ(dj_BB.first, vector<string>({"B"}));
+    EXPECT_EQ(dj_BB.first, std::vector<std::string>({"B"}));
   }
   {
     // "B" --> "C"
     const auto dj_BC = graph.CalcMinCostPathDijkstra("B", "C");
     EXPECT_EQ(dj_BC.second, 2.0);
-    EXPECT_EQ(dj_BC.first, vector<string>({"B", "C"}));
+    EXPECT_EQ(dj_BC.first, std::vector<std::string>({"B", "C"}));
   }
   {
     // "B" --> "D"
     const auto dj_BD = graph.CalcMinCostPathDijkstra("B", "D");
     EXPECT_EQ(dj_BD.second, 2.0);
-    EXPECT_EQ(dj_BD.first, vector<string>({"B", "C", "D"}));
+    EXPECT_EQ(dj_BD.first, std::vector<std::string>({"B", "C", "D"}));
   }
   {
     // "B" --> "E"
     const auto dj_BE = graph.CalcMinCostPathDijkstra("B", "E");
     EXPECT_EQ(dj_BE.second, 5.0);
-    EXPECT_EQ(dj_BE.first, vector<string>({"B", "C", "E"}));    
+    EXPECT_EQ(dj_BE.first, std::vector<std::string>({"B", "C", "E"}));
   }
 }
 
@@ -130,32 +128,32 @@ TEST(GraphTest, DijkstraC) {
   {
     // "C" --> "A"
     const auto dj_CA = graph.CalcMinCostPathDijkstra("C", "A");
-    EXPECT_EQ(dj_CA.second, numeric_limits<double>::infinity());
-    EXPECT_EQ(dj_CA.first, vector<string>({}));
+    EXPECT_EQ(dj_CA.second, std::numeric_limits<double>::infinity());
+    EXPECT_EQ(dj_CA.first, std::vector<std::string>({}));
   }
   {
     // "C" --> "B"
     const auto dj_CB = graph.CalcMinCostPathDijkstra("C", "B");
-    EXPECT_EQ(dj_CB.second, numeric_limits<double>::infinity());
-    EXPECT_EQ(dj_CB.first, vector<string>({}));
+    EXPECT_EQ(dj_CB.second, std::numeric_limits<double>::infinity());
+    EXPECT_EQ(dj_CB.first, std::vector<std::string>({}));
   }
   {
     // "C" --> "C"
     const auto dj_CC = graph.CalcMinCostPathDijkstra("C", "C");
     EXPECT_EQ(dj_CC.second, 0.0);
-    EXPECT_EQ(dj_CC.first, vector<string>({"C"}));
+    EXPECT_EQ(dj_CC.first, std::vector<std::string>({"C"}));
   }
   {
     // "C" --> "D"
     const auto dj_CD = graph.CalcMinCostPathDijkstra("C", "D");
     EXPECT_EQ(dj_CD.second, 0.0);
-    EXPECT_EQ(dj_CD.first, vector<string>({"C", "D"}));
+    EXPECT_EQ(dj_CD.first, std::vector<std::string>({"C", "D"}));
   }
   {
     // "C" --> "E"
     const auto dj_CE = graph.CalcMinCostPathDijkstra("C", "E");
     EXPECT_EQ(dj_CE.second, 3.0);
-    EXPECT_EQ(dj_CE.first, vector<string>({"C", "E"}));
+    EXPECT_EQ(dj_CE.first, std::vector<std::string>({"C", "E"}));
   }
 }
 
@@ -164,32 +162,32 @@ TEST(GraphTest, DijkstraD) {
   {
     // "D" --> "A"
     const auto dj_DA = graph.CalcMinCostPathDijkstra("D", "A");
-    EXPECT_EQ(dj_DA.second, numeric_limits<double>::infinity());
-    EXPECT_EQ(dj_DA.first, vector<string>({}));
+    EXPECT_EQ(dj_DA.second, std::numeric_limits<double>::infinity());
+    EXPECT_EQ(dj_DA.first, std::vector<std::string>({}));
   }
   {
     // "D" --> "B"
     const auto dj_DB = graph.CalcMinCostPathDijkstra("D", "B");
-    EXPECT_EQ(dj_DB.second, numeric_limits<double>::infinity());
-    EXPECT_EQ(dj_DB.first, vector<string>({}));
+    EXPECT_EQ(dj_DB.second, std::numeric_limits<double>::infinity());
+    EXPECT_EQ(dj_DB.first, std::vector<std::string>({}));
   }
   {
     // "D" --> "C"
     const auto dj_DC = graph.CalcMinCostPathDijkstra("D", "C");
     EXPECT_EQ(dj_DC.second, 0.0);
-    EXPECT_EQ(dj_DC.first, vector<string>({"D", "C"}));
+    EXPECT_EQ(dj_DC.first, std::vector<std::string>({"D", "C"}));
   }
   {
     // "D" --> "D"
     const auto dj_DD = graph.CalcMinCostPathDijkstra("D", "D");
     EXPECT_EQ(dj_DD.second, 0.0);
-    EXPECT_EQ(dj_DD.first, vector<string>({"D"}));
+    EXPECT_EQ(dj_DD.first, std::vector<std::string>({"D"}));
   }
   {
     // "D" --> "E"
     const auto dj_DE = graph.CalcMinCostPathDijkstra("D", "E");
     EXPECT_EQ(dj_DE.second, 3.0);
-    EXPECT_EQ(dj_DE.first, vector<string>({"D", "C", "E"}));
+    EXPECT_EQ(dj_DE.first, std::vector<std::string>({"D", "C", "E"}));
   }
 }
 
@@ -198,33 +196,31 @@ TEST(GraphTest, DijkstraE) {
   {
     // "E" --> "A"
     const auto dj_EA = graph.CalcMinCostPathDijkstra("E", "A");
-    EXPECT_EQ(dj_EA.second, numeric_limits<double>::infinity());
-    EXPECT_EQ(dj_EA.first, vector<string>({}));
+    EXPECT_EQ(dj_EA.second, std::numeric_limits<double>::infinity());
+    EXPECT_EQ(dj_EA.first, std::vector<std::string>({}));
   }
   {
     // "E" --> "B"
     const auto dj_EB = graph.CalcMinCostPathDijkstra("E", "B");
-    EXPECT_EQ(dj_EB.second, numeric_limits<double>::infinity());
-    EXPECT_EQ(dj_EB.first, vector<string>({}));
+    EXPECT_EQ(dj_EB.second, std::numeric_limits<double>::infinity());
+    EXPECT_EQ(dj_EB.first, std::vector<std::string>({}));
   }
   {
     // "E" --> "C"
     const auto dj_EC = graph.CalcMinCostPathDijkstra("E", "C");
-    EXPECT_EQ(dj_EC.second, numeric_limits<double>::infinity());
-    EXPECT_EQ(dj_EC.first, vector<string>({}));
+    EXPECT_EQ(dj_EC.second, std::numeric_limits<double>::infinity());
+    EXPECT_EQ(dj_EC.first, std::vector<std::string>({}));
   }
   {
     // "E" --> "D"
     const auto dj_ED = graph.CalcMinCostPathDijkstra("E", "D");
-    EXPECT_EQ(dj_ED.second, numeric_limits<double>::infinity());
-    EXPECT_EQ(dj_ED.first, vector<string>({}));
+    EXPECT_EQ(dj_ED.second, std::numeric_limits<double>::infinity());
+    EXPECT_EQ(dj_ED.first, std::vector<std::string>({}));
   }
   {
     // "E" --> "E"
     const auto dj_EE = graph.CalcMinCostPathDijkstra("E", "E");
     EXPECT_EQ(dj_EE.second, 0.0);
-    EXPECT_EQ(dj_EE.first, vector<string>({"E"}));
+    EXPECT_EQ(dj_EE.first, std::vector<std::string>({"E"}));
   }
 }
-
-}  // namespace std


### PR DESCRIPTION
I previously had `using namespace std` which I changed to `namespace std {}` to address a lint error. The fix `namespace std {}` fixed the lint issue, but adds names to the `std` name space which isn't what I want to do.

This PR addresses the issue by putting `std` in front of everything that comes from the `std` namespace. For example `vector` becomes `std::vector`. This is good practice and should help prevent potential future name clashes.